### PR TITLE
Further fix for soap_request() encryption

### DIFF
--- a/panasonic_viera/__init__.py
+++ b/panasonic_viera/__init__.py
@@ -184,7 +184,7 @@ class RemoteControl:
         is_encrypted = False
         
         # Encapsulate URN_REMOTE_CONTROL command in an X_EncryptedCommand if we're using encryption
-        if urn == URN_REMOTE_CONTROL and action not in ["X_GetEncryptSessionId", "X_DisplayPinCode"]:
+        if urn == URN_REMOTE_CONTROL and action not in ["X_GetEncryptSessionId", "X_DisplayPinCode", "X_RequestAuth"]:
             if None not in [self._session_key, self._session_iv, self._session_hmac_key, self._session_id, self._session_seq_num]:
                 is_encrypted = True
                 self._session_seq_num += 1


### PR DESCRIPTION
Further fixing soap_request() to prevent incorrect enforcement of encryption on pin-related requests (added "X_RequestAuth" to list of action exclusions). See https://github.com/florianholzapfel/panasonic-viera/pull/14 - thanks to @dawiinci for pointing this out.

Tested and working on my Panasonic TX-55FZ952B.