### PR TITLE
Making encryption variables public

### DIFF
--- a/panasonic_viera/__init__.py
+++ b/panasonic_viera/__init__.py
@@ -584,3 +584,15 @@ class RemoteControl:
     def media_previous_track(self):
         """Send the previous track command."""
         self.send_key(Keys.rewind)
+
+    @property
+    def type(self):
+        return self._type
+    
+    @property
+    def app_id(self):
+        return self._app_id
+    
+    @property
+    def enc_key(self):
+        return self._enc_key


### PR DESCRIPTION
Hi, @florianholzapfel!

I know you don't visit this project in a while, but here I am, making a pull request. So, I'm [updating the Panasonic Viera integration in Home Assistant](https://github.com/home-assistant/core/pull/33829) (which is something I saw you worked on - and that's pretty cool), to support encrypted connections, but their guidelines won't allow me to retrieve protected variables (`_type`, `_app_id` and `_enc_key`), so my only option was to change the library's source code.

My changes are very simple (I just added functions with `@property` decorators to make the variables public), and I hope you accept them.

:D