### PR TITLE
Add method get_device_info

### DIFF
--- a/panasonic_viera/__init__.py
+++ b/panasonic_viera/__init__.py
@@ -330,6 +330,7 @@ class RemoteControl:
                     if child.tag.endswith("errorDescription"):
                         raise SOAPError(child.text)
                 return
+            raise e # Pass to the next handler
         root = etree.fromstring(res)
         self._challenge = bytearray(base64.b64decode(root.find('.//X_ChallengeKey').text))
     
@@ -371,6 +372,7 @@ class RemoteControl:
                     elif child.tag.endswith("errorDescription"):
                         raise SOAPError(child.text)
                 return
+            raise e # Pass to the next handler
         
         # Parse and decrypt X_AuthResult
         root = etree.fromstring(res)
@@ -411,6 +413,7 @@ class RemoteControl:
                     if child.tag.endswith("errorDescription"):
                         raise SOAPError(child.text)
                 return
+            raise e # Pass to the next handler
         
         root = etree.fromstring(res)
         enc_result = root.find('.//X_EncResult').text

--- a/panasonic_viera/__init__.py
+++ b/panasonic_viera/__init__.py
@@ -611,9 +611,3 @@ class RemoteControl:
     def enc_key(self):
         """Return encryption key."""
         return self._enc_key
-
-def etree_to_dict(t):
-    d = {t.tag : map(etree_to_dict, t.iterchildren())}
-    d.update(('@' + k, v) for k, v in t.attrib.iteritems())
-    d['text'] = t.text
-    return d

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     download_url = 'https://github.com/florianholzapfel/panasonic-viera/archive/master.zip',
     keywords = ['panasonic', 'viera'],
     classifiers = [],
-    install_requires = ['pycryptodome'],
+    install_requires = ['pycryptodome', 'xmltodict'],
 )


### PR DESCRIPTION
This PR adds a `get_device_info` method that returns a Python dictionary parsed from a descriptor XML file (`dmr/ddd.xml`).

Some of the values that can be extracted from it are: `deviceType`, `friendlyName`, `manufacturer`, `modelName`,` modelNumber` and `UDN` (a unique identifier).

It also fixes #28 by preventing the variable `res` from being referenced before assignment after try...except statements.

@florianholzapfel did I put `xmltodict` in the right field inside `setup.py`?